### PR TITLE
Remove `trans` attribute from .tmx files

### DIFF
--- a/data/levels/tmx/0-introduction.tmx
+++ b/data/levels/tmx/0-introduction.tmx
@@ -7,7 +7,7 @@
   <property name="turns_to_ace" type="int" value="4"/>
  </properties>
  <tileset firstgid="1" name="newtiledsheet" tilewidth="16" tileheight="16" tilecount="90" columns="9">
-  <image source="../../newtiledsheet.png" trans="ff00ff" width="144" height="160"/>
+  <image source="../../newtiledsheet.png" width="144" height="160"/>
   <tile id="0">
    <properties>
     <property name="destructable" value=""/>

--- a/data/levels/tmx/1-introduction.tmx
+++ b/data/levels/tmx/1-introduction.tmx
@@ -7,7 +7,7 @@
   <property name="turns_to_ace" type="int" value="4"/>
  </properties>
  <tileset firstgid="1" name="newtiledsheet" tilewidth="16" tileheight="16" tilecount="126" columns="9">
-  <image source="../../newtiledsheet.png" trans="ff00ff" width="144" height="224"/>
+  <image source="../../newtiledsheet.png" width="144" height="224"/>
   <tile id="0">
    <properties>
     <property name="destructable" value=""/>

--- a/data/levels/tmx/1-level.tmx
+++ b/data/levels/tmx/1-level.tmx
@@ -4,7 +4,7 @@
   <property name="player_bomb_count" value="0"/>
  </properties>
  <tileset firstgid="1" name="newtiledsheet" tilewidth="16" tileheight="16" tilecount="144" columns="9">
-  <image source="../../newtiledsheet.png" trans="ff00ff" width="144" height="256"/>
+  <image source="../../newtiledsheet.png" width="144" height="256"/>
   <tile id="0">
    <properties>
     <property name="destructable" value=""/>

--- a/data/levels/tmx/2-introduction.tmx
+++ b/data/levels/tmx/2-introduction.tmx
@@ -5,7 +5,7 @@
   <property name="turns_to_ace" type="int" value="4"/>
  </properties>
  <tileset firstgid="1" name="newtiledsheet" tilewidth="16" tileheight="16" tilecount="144" columns="9">
-  <image source="../../newtiledsheet.png" trans="ff00ff" width="144" height="256"/>
+  <image source="../../newtiledsheet.png" width="144" height="256"/>
   <tile id="0">
    <properties>
     <property name="destructable" value=""/>

--- a/data/levels/tmx/2-level.tmx
+++ b/data/levels/tmx/2-level.tmx
@@ -4,7 +4,7 @@
   <property name="player_bomb_count" value="2"/>
  </properties>
  <tileset firstgid="1" name="newtiledsheet" tilewidth="16" tileheight="16" tilecount="63" columns="9">
-  <image source="../../newtiledsheet.png" trans="ff00ff" width="144" height="112"/>
+  <image source="../../newtiledsheet.png" width="144" height="112"/>
   <tile id="0">
    <properties>
     <property name="destructable" value=""/>

--- a/data/levels/tmx/completed-tutorial.tmx
+++ b/data/levels/tmx/completed-tutorial.tmx
@@ -7,7 +7,7 @@
   <property name="turns_to_ace" type="int" value="4"/>
  </properties>
  <tileset firstgid="1" name="newtiledsheet" tilewidth="16" tileheight="16" tilecount="144" columns="9">
-  <image source="../../newtiledsheet.png" trans="ff00ff" width="144" height="256"/>
+  <image source="../../newtiledsheet.png" width="144" height="256"/>
   <tile id="0">
    <properties>
     <property name="destructable" value=""/>

--- a/src/level_editor.py
+++ b/src/level_editor.py
@@ -25,8 +25,6 @@ class LevelData():
         self.map_layer_for_camera = pyscroll.BufferedRenderer(
             self.map_data_for_camera,
             (100, 100),
-            # colorkey=((0,0,0))
-            alpha=True
         )
 
         self.sprites = pyscroll.PyscrollGroup(


### PR DESCRIPTION
This was breaking transparency for some reason. Details in #46
but copied here for historical reasons:

Bitcraft:
i took a look at your transparency issue and found it. it was an odd
one... if you look at the tmx level files, you'll notice that the
tileset images have a attribute called "trans" set.

  <image source="../../newtiledsheet.png" trans="ff00ff" width="144"
  height="224"/> this is supposed to mean "colorkey". what is happening
  here is that the maps are loaded with pytmx as 32-bit images with an
  alpha channel. pyscroll will reduce all the tiles when loaded so it
  draws faster, if possible. because tiled has a colorkey set (the trans
  attribute), pyscroll tries to treat the tiles as having a color key,
  so the alpha channel is lost and leaves some tiles with an ugly
  border.

the alpha kwarg for the bufferered renderer isn't obvious. all tiles
will have an alpha channel if they require it, but the layers do not.
this flag means "give the layers an alpha channel". enabling reduces
performance by about 30% because there are 8 more bits to write per
pixel for each layer, so it is disabled by default. it is only needed
for parallax scrolling and other effects.

TL;DR - your tileset is misconfigured to use a color key when it really
has a alpha channel

edit the tmx files and remove the color key attribute ("trans") remove
the "alpha=True" kwarg from the pyscroll buffered renderer