### PR TITLE
Remove collision handler from actor.py

### DIFF
--- a/src/game_object/actor.py
+++ b/src/game_object/actor.py
@@ -46,8 +46,7 @@ class Actor(entity.Entity):
         self.direction = 'down'
         self.speed = 6
         self.distance = graphics.tile_width
-        self.level = level
-        self.tiled_level = self.level.tiled_level
+        self.tiled_level = level.tiled_level
         self.bombs = pygame.sprite.LayeredUpdates()
         self.move_stack = []
         self.destination = [self.rect.x, self.rect.y]
@@ -55,10 +54,6 @@ class Actor(entity.Entity):
         self.moving = False
         self.turns_taken = 0
         self.is_teleporting = False
-        self.collision_handler = TurnBasedCollisionHandler(
-            self, self.level
-        )
-
         self.minimap_colour = colours.BLUE_HIGHLIGHT
 
     def move(self, delta_time):
@@ -157,7 +152,7 @@ class Actor(entity.Entity):
 
     def is_dead(self):
         """Returns true if the player is dead"""
-        return self not in self.level.sprites
+        return self not in self.tiled_level.sprites
 
     def animate(self):
         pass

--- a/src/input_handlers/global_input_handler.py
+++ b/src/input_handlers/global_input_handler.py
@@ -18,12 +18,8 @@ class GlobalInputHandler():
         self.level = level
         self.player = player
 
-        self.player_input_handler = PlayerInputHandler(player)
-
-        self.level_input_handler = InputHandler(
-            self.player,
-            self.level
-        )
+        self.player_input_handler = PlayerInputHandler(player, level)
+        self.level_input_handler = InputHandler(player, level)
 
         self.event_handler = event_handler.EventHandler(level, player)
 

--- a/src/input_handlers/player_input_handler.py
+++ b/src/input_handlers/player_input_handler.py
@@ -25,12 +25,13 @@ class PlayerInputHandler():
         pygame.K_l: 'right',
     }
 
-    def __init__(self, player):
+    def __init__(self, player, level):
         self.player = player
+        self.level = level
 
     def process_input(self, event):
         for key, action in PlayerInputHandler.keys.items():
             if event.key == key:
                 self.player.event_update(action)
-                self.player.collision_handler.update()
+                self.level.turn_based_collision_handler.update()
                 self.player.add_turn()

--- a/src/scenes/levelbase.py
+++ b/src/scenes/levelbase.py
@@ -7,6 +7,7 @@ import src.renderers.level_base_renderer as renderers
 import src.input_handlers.global_input_handler as input_handler
 import src.environment
 from src.collision_handlers.polling_collision_handler import PollingCollisionHandler
+from src.collision_handlers.turn_based_collision_handler import TurnBasedCollisionHandler
 from src.save import SaveGame
 
 
@@ -54,6 +55,7 @@ class LevelBase(scene_base.SceneBase):
         self.sprites.add(self.player)
         self.renderer = renderers.LevelBaseRenderer(self)
         self.collision_handler = PollingCollisionHandler(self.player, self)
+        self.turn_based_collision_handler = TurnBasedCollisionHandler(self.player, self)
 
     def check_player_hasnt_died_a_horrible_death(self):
         """If the player has been destroyed, restart the level"""


### PR DESCRIPTION
# Regression testing

This is in place until we get some kind of automated testing done but it's a bit of a pain with games (or pygame at least).
Play through the game and confirm the following:

- [x] - Bombs do not pass through solids
- [x] - Once a moveable tile has been moved, bombs do not pass through it (or before it was moved)
- [x] - A user stepping on a pressure plate activates the pressure plate
- [x] - A user stepping off a pressure plate deactivates the pressure plate
- [x] - The minimap is displaying properly
- [x] - Moveable tiles cannot be pushed through solid
- [x] - Explosions stop at stairs
- [x] - Lasers kill you if you walk into them
