### PR TITLE
Feature/pin bomb to platform

### DIFF
--- a/data/levels/tmx/dumping-ground.tmx
+++ b/data/levels/tmx/dumping-ground.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.3" orientation="orthogonal" renderorder="right-down" width="25" height="18" tilewidth="16" tileheight="16" infinite="0" nextlayerid="12" nextobjectid="336">
+<map version="1.4" tiledversion="1.4.3" orientation="orthogonal" renderorder="right-down" width="25" height="18" tilewidth="16" tileheight="16" infinite="0" nextlayerid="12" nextobjectid="351">
  <properties>
   <property name="display_name" value="Learning To Walk"/>
   <property name="next_level" value="./data/levels/tmx/L03-Pushing.tmx"/>
@@ -355,6 +355,31 @@
     <property name="follows_path_id" type="int" value="5"/>
    </properties>
   </object>
+  <object id="336" type="moving_platform" gid="53" x="192" y="160" width="16" height="16">
+   <properties>
+    <property name="follows_path_id" type="int" value="7"/>
+   </properties>
+  </object>
+  <object id="339" type="triggerable" gid="8" x="192" y="176" width="16" height="16">
+   <properties>
+    <property name="triggered_id" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="340" type="switch" gid="34" x="208" y="176" width="16" height="16">
+   <properties>
+    <property name="triggers" type="int" value="1"/>
+   </properties>
+  </object>
+  <object id="341" type="tile" gid="11" x="224" y="176" width="16" height="16"/>
+  <object id="342" type="tile" gid="11" x="208" y="192" width="16" height="16"/>
+  <object id="343" type="tile" gid="11" x="208" y="208" width="16" height="16"/>
+  <object id="344" type="tile" gid="11" x="208" y="224" width="16" height="16"/>
+  <object id="345" type="tile" gid="11" x="208" y="240" width="16" height="16"/>
+  <object id="346" type="tile" gid="2" x="176" y="176" width="16" height="16"/>
+  <object id="347" type="tile" gid="2" x="176" y="192" width="16" height="16"/>
+  <object id="348" type="tile" gid="2" x="176" y="208" width="16" height="16"/>
+  <object id="349" type="tile" gid="2" x="176" y="224" width="16" height="16"/>
+  <object id="350" type="tile" gid="2" x="176" y="240" width="16" height="16"/>
  </objectgroup>
  <objectgroup id="11" name="paths">
   <object id="182" type="path" x="304" y="256">
@@ -387,11 +412,17 @@
    </properties>
    <polyline points="-0.16,-48 -0.16,-32"/>
   </object>
-  <object id="335" type="path" x="176" y="144">
+  <object id="337" type="path" x="176" y="144">
    <properties>
     <property name="path_id" type="int" value="5"/>
    </properties>
    <polyline points="0,0 0,-16"/>
+  </object>
+  <object id="338" type="path" x="192" y="144">
+   <properties>
+    <property name="path_id" type="int" value="7"/>
+   </properties>
+   <polyline points="0,0 16,0"/>
   </object>
  </objectgroup>
 </map>

--- a/src/collision_handlers/polling_collision_handler.py
+++ b/src/collision_handlers/polling_collision_handler.py
@@ -18,7 +18,7 @@ class PollingCollisionHandler():
         self.player = player
         self.level = level
         self.polling_instances = (
-            BombParticle,
+            # BombParticle,
             MovingLaser,
             Bullet, 
             PressurePlate, 

--- a/src/game_object/moving_platform.py
+++ b/src/game_object/moving_platform.py
@@ -40,6 +40,14 @@ class MovingPlatform(entity.Entity):
         player.destination[0] = x
         player.destination[1] = y
 
+    def pin_bomb(self, bomb, x, y):
+        """
+        Pins the player to x and y.
+        Otherwise they wouldn't move
+        """
+        bomb.rect.x = x
+        bomb.rect.y = y
+
     def handle_collision(self, tile, player, level):
         self.timer -= 1
 
@@ -51,7 +59,7 @@ class MovingPlatform(entity.Entity):
             if heading != [0,0]:
                 heading.normalize_ip()
 
-            if distance <= 1:  # We're closer than 2 pixels.
+            if distance <= 1:  # We're closer than a pixel
                 self.waypoint_index = (self.waypoint_index + 1) % len(self.path.points)
                 self.target = self.path.points[self.waypoint_index]
 
@@ -59,14 +67,22 @@ class MovingPlatform(entity.Entity):
             self.position += self.vel
             self.rect.topleft = self.position
 
+            for bomb in player.bombs:
+                # Pin bombs to the platform if we've planted any
+                if pygame.sprite.collide_rect(self, bomb):
+                    self.pin_bomb(bomb, self.position.x, self.position.y)
+
             if pygame.sprite.collide_rect(self, player):
                 self.pin_player(player, self.position.x, self.position.y)
+
 
             """Filled green and red for now to visualise.
             Green is safe to go on. Red is not, if it's red and we 
             try and go on, we should die."""
             if self.rect.x % 16 == 0 and self.rect.y % 16 == 0:
                 self.image.fill((0, 255,0))
+
+                # Time to wait before moving again
                 self.timer = 50
             else:
                 self.image.fill((140,0,0))


### PR DESCRIPTION
# Regression testing

This is in place until we get some kind of automated testing done but it's a bit of a pain with games (or pygame at least).
Play through the game and confirm the following:

### Bombs
- [ ] - Bombs do not pass through solids
- [ ] - Explosions stop at stairs
- [ ] - A user walking into a solid tile while a bomb detonates will die
- [ ] - Explosion blow up destructible objects
- [ ] - Bombs do not blow up things when collected at 1

### Moveable tiles
- [ ] - Once a moveable tile has been moved, bombs do not pass through it (or before it was moved)
- [ ] - Moveable tiles cannot be pushed through solid
- [ ] - A user cannot walk into a moveable tile if that tile is up against a solid object

### Pressure plates
- [ ] - A user stepping on a pressure plate activates the pressure plate
- [ ] - A user stepping off a pressure plate deactivates the pressure plate

### Lasers
- [ ] - Lasers kill you if you walk into them

### Minimap
- [ ] - The minimap is displaying properly

### Other
- [ ] - Tiles can have other tiles beneath them
