### PR TITLE
Add controller prompts

### DIFF
--- a/assets/game-data/saved-games/game-data.json
+++ b/assets/game-data/saved-games/game-data.json
@@ -1,1 +1,1 @@
-{"settings": {"music": false}, "has_seen_introduction": true, "last_played_level": "assets/game-data/levels/level-1.tmx"}
+{"settings": {"music": false}, "has_seen_introduction": true}

--- a/src/gui/top_bar.py
+++ b/src/gui/top_bar.py
@@ -24,8 +24,8 @@ class TopBar():
         )
 
         self.level_name_display = DataDisplay(
-            self.width // 4,
-            self.height // 4,
+            self.width * 0.25,
+            self.height * 0.25,
             self.width,
             self.height,
             self.surface,

--- a/src/input_handlers/keyboard_controller.py
+++ b/src/input_handlers/keyboard_controller.py
@@ -1,4 +1,5 @@
 import pygame
+import os
 
 class KeyboardController():
 
@@ -12,6 +13,17 @@ class KeyboardController():
 
     def get_up_button_state():
         return pygame.K_UP
+
+    def get_action_button_image():
+        base_path = os.path.join(
+            'assets', 
+            'images', 
+            'controller-prompts',
+            'keyboard-and-mouse', 
+            'Light' + os.sep
+        )
+
+        return pygame.image.load(base_path + 'Space_Key_Light.png')
 
     def get_left_button_state():
         return pygame.K_LEFT
@@ -30,3 +42,5 @@ class KeyboardController():
 
     def get_escape_button_state():
         return pygame.K_ESCAPE
+
+    

--- a/src/input_handlers/xbox_360_controller.py
+++ b/src/input_handlers/xbox_360_controller.py
@@ -1,3 +1,5 @@
+import pygame
+import os
 
 class Xbox360Controller():
 
@@ -35,6 +37,16 @@ class Xbox360Controller():
         """Gets the state of the A button"""
         return self.joystick.get_button(0)
 
+    def get_action_button_image(self):
+        base_path = os.path.join(
+            'assets', 
+            'images', 
+            'controller-prompts',
+            'xbox-one' + os.sep
+        )
+
+        return pygame.image.load(base_path + 'XboxOne_A.png')
+
     def get_y_button_state(self):
         """Gets the state of the A button"""
         return self.joystick.get_button(3)
@@ -44,6 +56,12 @@ class Xbox360Controller():
 
     def get_up_button_state(self):
         return int(self.joystick.get_hat(0) == (0, 1))
+
+    def get_left_button_state(self):
+        return int(self.joystick.get_hat(0) == (-1, 0))
+
+    def get_right_button_state(self):
+        return int(self.joystick.get_hat(0) == (1, 0))
 
     def get_start_button_state(self):
         return self.joystick.get_button(7)

--- a/src/scenes/introduction_text_overlay.py
+++ b/src/scenes/introduction_text_overlay.py
@@ -14,22 +14,24 @@ class IntroductionTextOverlay(scene_base.SceneBase):
 
     def __init__(self):
         # TODO needs its own input handler
+        self.controller = graphics.get_controller()
         scene_base.SceneBase.__init__(
             self, 
             IntroductionTextOverlayInputHandler(self),
-            graphics.get_controller()
+            self.controller
         ) 
 
         self.user_data = UserData()
         self.screen = graphics.get_window_surface()
+        self.screen_surface_rect = self.screen.get_rect()
         self.width, self.height = pygame.display.get_window_size()
         self.center = self.width // 2
         self.surface = pygame.Surface((self.width, self.height)).convert()
 
+        self.size = pygame.display.get_window_size()
         self.asset_sizer = ResolutionAssetSizer()
-        self.font_size = self.asset_sizer.get_font_size(
-            pygame.display.get_window_size()
-        )
+        self.font_size = self.asset_sizer.get_font_size(self.size)
+
         pygame.font.init()
         self.font = pygame.font.Font(config.font, self.font_size)
         self.timer = 100
@@ -39,6 +41,11 @@ class IntroductionTextOverlay(scene_base.SceneBase):
             I hear from 'The Others' that he's guilty of leaving evidence of these experiments just lying around.
             I should collect these and finally expose his wicked games!"
             """
+
+        self.action_image = self.controller.get_action_button_image()
+        self.controller_prompt_x, self.controller_prompt_y = self.screen_surface_rect.midbottom
+        self.controller_prompt_x = self.screen_surface_rect.centerx * 0.75
+        self.controller_prompt_y -= self.asset_sizer.get_button_size(self.size)[0]
 
     def render(self):
         """Renders all the buttons on our escape menu"""
@@ -56,6 +63,28 @@ class IntroductionTextOverlay(scene_base.SceneBase):
             )
 
             self.screen.blit(self.surface, (0,0))
+
+            rendered_text = self.font.render("Press ", False, colours.WHITE)
+            rendered_text_other = self.font.render("To continue ", False, colours.WHITE)
+
+            self.screen.blit(
+                rendered_text, 
+                (self.controller_prompt_x, self.controller_prompt_y)
+            )
+
+            self.screen.blit(
+                self.action_image, 
+                (self.controller_prompt_x + rendered_text.get_width(), self.controller_prompt_y)
+            )
+
+            self.screen.blit(
+                rendered_text_other, 
+                (
+                    self.controller_prompt_x + rendered_text.get_width() + self.action_image.get_width() , 
+                    self.controller_prompt_y
+                )
+            )
+
         else: 
             self.switch_to_scene(src.static_scenes.level_obj_list['level-select'])
 

--- a/src/scenes/text_overlay.py
+++ b/src/scenes/text_overlay.py
@@ -12,22 +12,31 @@ class TextOverlay(scene_base.SceneBase):
 
     def __init__(self, text, redirect_to):
         self.redirect_to = redirect_to
+        self.size = pygame.display.get_window_size()
+        self.controller = graphics.get_controller()
 
         scene_base.SceneBase.__init__(
             self, 
             TextOverlayInputHandler(self),
-            graphics.get_controller()
+            self.controller
         ) 
+
         self.text = text
         self.width, self.height = pygame.display.get_window_size()
         self.center = self.width // 2
         self.asset_sizer = ResolutionAssetSizer()
         self.surface = pygame.Surface((self.width, self.height)).convert()
         self.font_size = self.asset_sizer.get_font_size(
-            pygame.display.get_window_size()
+            self.size
         )
         self.font = pygame.font.Font(config.font, self.font_size)
         self.screen_surface = graphics.get_window_surface()
+        self.screen_surface_rect = self.screen_surface.get_rect()
+
+        self.action_image = self.controller.get_action_button_image()
+        self.controller_prompt_x, self.controller_prompt_y = self.screen_surface_rect.midbottom
+        self.controller_prompt_x = self.screen_surface_rect.centerx * 0.75
+        self.controller_prompt_y -= self.asset_sizer.get_button_size(self.size)[0]
 
     def render(self):
         """Renders all the buttons on our escape menu"""
@@ -43,6 +52,28 @@ class TextOverlay(scene_base.SceneBase):
         )
 
         self.screen_surface.blit(self.surface, (0,0))
+
+        rendered_text = self.font.render("Press ", False, colours.WHITE)
+        rendered_text_other = self.font.render("To continue ", False, colours.WHITE)
+
+        self.screen_surface.blit(
+            rendered_text, 
+            (self.controller_prompt_x, self.controller_prompt_y)
+        )
+
+        self.screen_surface.blit(
+            self.action_image, 
+            (self.controller_prompt_x + rendered_text.get_width(), self.controller_prompt_y)
+        )
+
+        self.screen_surface.blit(
+            rendered_text_other, 
+            (
+                self.controller_prompt_x + rendered_text.get_width() + self.action_image.get_width() , 
+                self.controller_prompt_y
+            )
+        )
+
 
     def wrap_text(self, text: str, font, colour, x, y, screen, allowed_width):
         # first, split the text into words


### PR DESCRIPTION
This adds the respective logic to display keyboard/xbox/ps4 buttons at
certain points.

The gist is that each controller is responsible for fetching its image.

# Regression testing

This is in place until we get some kind of automated testing done but it's a bit of a pain with games (or pygame at least).
Play through the game and confirm the following:

### Bombs
- [ ] - Bombs do not pass through solids
- [ ] - Explosions stop at stairs
- [ ] - A user walking into a solid tile while a bomb detonates will die
- [ ] - Explosion blow up destructible objects
- [ ] - Bombs do not blow up things when collected at 1

### Moveable tiles
- [ ] - Once a moveable tile has been moved, bombs do not pass through it (or before it was moved)
- [ ] - Moveable tiles cannot be pushed through solid
- [ ] - A user cannot walk into a moveable tile if that tile is up against a solid object

### Pressure plates
- [ ] - A user stepping on a pressure plate activates the pressure plate
- [ ] - A user stepping off a pressure plate deactivates the pressure plate

### Lasers
- [ ] - Lasers kill you if you walk into them

### Minimap
- [ ] - The minimap is displaying properly

### Other
- [ ] - Tiles can have other tiles beneath them
