### PR TITLE
Improve bomb animation

### DIFF
--- a/assets/game-data/levels/level-3.tmx
+++ b/assets/game-data/levels/level-3.tmx
@@ -1,30 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.4" tiledversion="1.4.3" orientation="orthogonal" renderorder="right-down" width="16" height="16" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="87">
+<map version="1.4" tiledversion="1.4.3" orientation="orthogonal" renderorder="right-down" width="16" height="16" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="122">
  <properties>
   <property name="player_bomb_count" type="int" value="100"/>
  </properties>
  <tileset firstgid="1" source="mr-figs.tsx"/>
+ <tileset firstgid="1711" source="newtiledsheet-32.tsx"/>
  <layer id="1" name="background" width="16" height="16">
   <data encoding="csv">
-13,202,202,202,202,202,202,128,128,128,128,128,128,280,0,0,
-51,229,229,229,229,229,305,229,229,229,229,229,0,280,0,0,
-51,229,229,229,305,229,128,128,128,128,128,128,128,318,0,0,
-51,229,229,229,305,229,280,0,0,0,0,0,0,0,0,0,
-51,229,229,229,229,229,280,0,0,0,0,0,0,0,0,0,
-51,229,229,229,229,229,280,0,0,0,0,0,0,0,0,0,
-316,317,317,317,317,317,318,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,
+1819,229,229,229,229,229,305,229,229,229,229,229,0,1819,1819,1819,
+1819,229,229,229,305,229,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,
+1819,229,229,229,305,229,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,
+1819,229,229,229,229,229,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,
+1819,229,229,229,229,229,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,
+1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,
+1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,
+1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,
+1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,
+1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,
+1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,
+1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,
+1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,
+1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,
+1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819,1819
 </data>
  </layer>
  <objectgroup id="2" name="objects">
+  <object id="118" type="tile" gid="317" x="256" y="32" width="32" height="32"/>
+  <object id="119" type="tile" gid="317" x="288" y="32" width="32" height="32"/>
+  <object id="120" type="tile" gid="317" x="192" y="32" width="32" height="32"/>
+  <object id="121" type="tile" gid="317" x="224" y="32" width="32" height="32"/>
   <object id="73" type="scene_switching_tile" gid="269" x="384" y="64" width="32" height="32">
    <properties>
     <property name="scene" value="todo-here"/>
@@ -91,5 +96,36 @@
    </properties>
   </object>
   <object id="86" type="actor" gid="45" x="32" y="160" width="32" height="32"/>
+  <object id="87" type="tile" gid="317" x="160" y="224" width="32" height="32"/>
+  <object id="88" type="tile" gid="317" x="192" y="192" width="32" height="32"/>
+  <object id="89" type="tile" gid="317" x="192" y="128" width="32" height="32"/>
+  <object id="90" type="tile" gid="317" x="192" y="96" width="32" height="32"/>
+  <object id="91" type="tile" gid="317" x="352" y="96" width="32" height="32"/>
+  <object id="92" type="tile" gid="317" x="416" y="64" width="32" height="32"/>
+  <object id="93" type="tile" gid="317" x="384" y="96" width="32" height="32"/>
+  <object id="94" type="tile" gid="317" x="288" y="96" width="32" height="32"/>
+  <object id="95" type="tile" gid="317" x="320" y="96" width="32" height="32"/>
+  <object id="96" type="tile" gid="317" x="224" y="96" width="32" height="32"/>
+  <object id="97" type="tile" gid="317" x="256" y="96" width="32" height="32"/>
+  <object id="98" type="tile" gid="317" x="192" y="160" width="32" height="32"/>
+  <object id="99" type="tile" gid="317" x="384" y="32" width="32" height="32"/>
+  <object id="100" type="tile" gid="317" x="416" y="32" width="32" height="32"/>
+  <object id="101" type="tile" gid="317" x="320" y="32" width="32" height="32"/>
+  <object id="102" type="tile" gid="317" x="352" y="32" width="32" height="32"/>
+  <object id="103" type="tile" gid="317" x="128" y="32" width="32" height="32"/>
+  <object id="104" type="tile" gid="317" x="160" y="32" width="32" height="32"/>
+  <object id="105" type="tile" gid="317" x="64" y="32" width="32" height="32"/>
+  <object id="106" type="tile" gid="317" x="96" y="32" width="32" height="32"/>
+  <object id="107" type="tile" gid="317" x="96" y="224" width="32" height="32"/>
+  <object id="108" type="tile" gid="317" x="128" y="224" width="32" height="32"/>
+  <object id="109" type="tile" gid="317" x="32" y="224" width="32" height="32"/>
+  <object id="110" type="tile" gid="317" x="64" y="224" width="32" height="32"/>
+  <object id="111" type="tile" gid="317" x="0" y="192" width="32" height="32"/>
+  <object id="112" type="tile" gid="317" x="0" y="128" width="32" height="32"/>
+  <object id="113" type="tile" gid="317" x="0" y="96" width="32" height="32"/>
+  <object id="114" type="tile" gid="317" x="0" y="160" width="32" height="32"/>
+  <object id="115" type="tile" gid="317" x="0" y="64" width="32" height="32"/>
+  <object id="116" type="tile" gid="317" x="0" y="32" width="32" height="32"/>
+  <object id="117" type="tile" gid="317" x="32" y="32" width="32" height="32"/>
  </objectgroup>
 </map>

--- a/src/game_object/actor.py
+++ b/src/game_object/actor.py
@@ -53,16 +53,15 @@ sprites = {
             g.spritesheet.subsurface(5 * g.tile_width, 16 * g.tile_height, g.tile_width, g.tile_height * 2),
         ],
         'planting_bomb': [
-            g.spritesheet.subsurface(0 * g.tile_width, 22 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(1 * g.tile_width, 22 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(2 * g.tile_width, 22 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(3 * g.tile_width, 22 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(4 * g.tile_width, 22 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(5 * g.tile_width, 22 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(4 * g.tile_width, 22 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(3 * g.tile_width, 22 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(2 * g.tile_width, 22 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(1 * g.tile_width, 22 * g.tile_height, g.tile_width, g.tile_height * 2),
+            g.spritesheet.subsurface(0 * g.tile_width, 22 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(2 * g.tile_width, 22 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(4 * g.tile_width, 22 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(6 * g.tile_width, 22 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(8 * g.tile_width, 22 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(6 * g.tile_width, 22 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(4 * g.tile_width, 22 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(2 * g.tile_width, 22 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(0 * g.tile_width, 22 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
         ]
     },
     'down': {
@@ -117,16 +116,15 @@ sprites = {
             g.spritesheet.subsurface(5 * g.tile_width, 12 * g.tile_height, g.tile_width, g.tile_height * 2),
         ],
         'planting_bomb': [
-            g.spritesheet.subsurface(0 * g.tile_width, 20 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(1 * g.tile_width, 20 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(2 * g.tile_width, 20 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(3 * g.tile_width, 20 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(4 * g.tile_width, 20 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(5 * g.tile_width, 20 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(4 * g.tile_width, 20 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(3 * g.tile_width, 20 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(2 * g.tile_width, 20 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(1 * g.tile_width, 20 * g.tile_height, g.tile_width, g.tile_height * 2),
+            g.spritesheet.subsurface(0 * g.tile_width, 20 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(2 * g.tile_width, 20 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(4 * g.tile_width, 20 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(6 * g.tile_width, 20 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(8 * g.tile_width, 20 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(6 * g.tile_width, 20 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(4 * g.tile_width, 20 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(2 * g.tile_width, 20 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(0 * g.tile_width, 20 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
         ]
     },
     'left': {
@@ -165,16 +163,15 @@ sprites = {
             g.spritesheet.subsurface(5 * g.tile_width, 18 * g.tile_height, g.tile_width, g.tile_height * 2),
         ],
         'planting_bomb': [
-            g.spritesheet.subsurface(0 * g.tile_width, 26 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(1 * g.tile_width, 26 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(2 * g.tile_width, 26 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(3 * g.tile_width, 26 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(4 * g.tile_width, 26 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(5 * g.tile_width, 26 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(4 * g.tile_width, 26 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(3 * g.tile_width, 26 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(2 * g.tile_width, 26 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(1 * g.tile_width, 26 * g.tile_height, g.tile_width, g.tile_height * 2),
+            g.spritesheet.subsurface(0 * g.tile_width , 26 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(1 * g.tile_width, 26 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(3 * g.tile_width, 26 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(5 * g.tile_width, 26 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(7 * g.tile_width, 26 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(5 * g.tile_width , 26 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(3 * g.tile_width , 26 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(1 * g.tile_width , 26 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(0 * g.tile_width , 26 * g.tile_height, g.tile_width, g.tile_height * 2),
         ]
     },
     'right': {
@@ -229,16 +226,15 @@ sprites = {
             g.spritesheet.subsurface(5 * g.tile_width, 14 * g.tile_height, g.tile_width, g.tile_height * 2),
         ],
         'planting_bomb': [
-            g.spritesheet.subsurface(0 * g.tile_width, 24 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(1 * g.tile_width, 24 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(2 * g.tile_width, 24 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(3 * g.tile_width, 24 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(4 * g.tile_width, 24 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(5 * g.tile_width, 24 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(4 * g.tile_width, 24 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(3 * g.tile_width, 24 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(2 * g.tile_width, 24 * g.tile_height, g.tile_width, g.tile_height * 2),
-            g.spritesheet.subsurface(1 * g.tile_width, 24 * g.tile_height, g.tile_width, g.tile_height * 2),
+            g.spritesheet.subsurface(0 * g.tile_width, 24 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(2 * g.tile_width, 24 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(4 * g.tile_width, 24 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(6 * g.tile_width, 24 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(8 * g.tile_width, 24 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(6 * g.tile_width, 24 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(4 * g.tile_width, 24 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(2 * g.tile_width, 24 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
+            g.spritesheet.subsurface(0 * g.tile_width, 24 * g.tile_height, g.tile_width * 2, g.tile_height * 2),
         ]
     },
 }
@@ -323,6 +319,7 @@ class Actor(entity.Entity):
 
         self.animation_timer = 0.125
         self.frame_index = 0
+        self.creating_bomb_frame_index = 0
 
         self.frames = sprites
 
@@ -437,6 +434,7 @@ class Actor(entity.Entity):
         if self.remaining_bombs and not self.moving:
 
             self.creating_bomb = True
+            self.creating_bomb_frame_index = 0
             # Don't plant a bomb here if there's already one there
             for bomb in self.bombs:
                 if bomb.rect.x == self.rect.x and bomb.rect.y == self.rect.y + self.offset_y:
@@ -470,13 +468,23 @@ class Actor(entity.Entity):
             self.frame_index += 1
 
             if self.creating_bomb:
-                self.image = self.frames[self.direction]['planting_bomb'][self.frame_index]
-
+                self.animate_bomb_create(delta_time)
             else: self.image = self.frames[self.direction][self.moving][self.frame_index]
 
             self.animation_timer = 0.125
 
+    def animate_bomb_create(self, dt):
+        print(self.creating_bomb_frame_index)
+        print(len(self.frames[self.direction]['planting_bomb']) - 1)
+
+        if self.creating_bomb_frame_index == len(self.frames[self.direction]['planting_bomb']) - 1:
             self.creating_bomb = False
+            return
+
+        self.creating_bomb_frame_index += 1
+
+        self.image = self.frames[self.direction]['planting_bomb'][self.creating_bomb_frame_index]
+
 
     def animate_death(self, dt):
         print('death animation here')


### PR DESCRIPTION
# Regression testing

This is in place until we get some kind of automated testing done but it's a bit of a pain with games (or pygame at least).
Play through the game and confirm the following:

### Bombs
- [ ] - Bombs do not pass through solids
- [ ] - Explosions stop at stairs
- [ ] - A user walking into a solid tile while a bomb detonates will die
- [ ] - Explosion blow up destructible objects
- [ ] - Bombs do not blow up things when collected at 1

### Moveable tiles
- [ ] - Once a moveable tile has been moved, bombs do not pass through it (or before it was moved)
- [ ] - Moveable tiles cannot be pushed through solid
- [ ] - A user cannot walk into a moveable tile if that tile is up against a solid object

### Pressure plates
- [ ] - A user stepping on a pressure plate activates the pressure plate
- [ ] - A user stepping off a pressure plate deactivates the pressure plate

### Lasers
- [ ] - Lasers kill you if you walk into them

### Minimap
- [ ] - The minimap is displaying properly

### Other
- [ ] - Tiles can have other tiles beneath them
